### PR TITLE
Fix: Update Cloudinary Upload Widget URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -690,7 +690,7 @@
     document.createElement( "picture" );
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/picturefill/3.0.2/picturefill.min.js"></script>
-  <script src="https://widget.cloudinary.com/v3.0/global/all.js" type="text/javascript"></script>
+  <script src="https://upload-widget.cloudinary.com/latest/global/all.js" type="text/javascript"></script>
   <script src="js/breakpoints.js"></script>
   <script>
     if (!document.location.host.match(/localhost/)) {


### PR DESCRIPTION
I updated the Cloudinary Upload Widget URL in public/index.html to the latest version.

This change addresses an issue where the widget was not functioning due to an outdated URL.